### PR TITLE
Fixes issue where album won't download if there was '_' in the url

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ListalRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ListalRipper.java
@@ -26,7 +26,7 @@ public class ListalRipper extends AbstractHTMLRipper {
 
     private Pattern p1 = Pattern.compile("https:\\/\\/www.listal.com\\/list\\/([a-zA-Z0-9-]+)");
     private Pattern p2 =
-            Pattern.compile("https:\\/\\/www.listal.com\\/((?:(?:[a-zA-Z0-9-]+)\\/?)+)");
+            Pattern.compile("https:\\/\\/www.listal.com\\/((?:(?:[a-zA-Z0-9-_]+)\\/?)+)");
     private String listId = null; // listId to get more images via POST.
     private String postUrl = "https://www.listal.com/item-list/"; //to load more images.
     private UrlType urlType = UrlType.UNKNOWN;


### PR DESCRIPTION
Adds '_' to the regex expression that checks the URL. Fixes an issue where albums won't download if there was a '_' character in the URL.

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1863)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Adds '_' to the regex expression that checks the URL. Fixes an issue where albums won't download if there was a '_' character in the URL.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
